### PR TITLE
feat: fix server API compatibility + add favorites, recent, chunked u…

### DIFF
--- a/lib/core/entities/favorite_item.dart
+++ b/lib/core/entities/favorite_item.dart
@@ -1,0 +1,55 @@
+import 'package:equatable/equatable.dart';
+
+/// Favorite item entity
+class FavoriteItem extends Equatable {
+  final String id;
+  final String itemId;
+  final String itemType; // 'file' or 'folder'
+  final String name;
+  final String path;
+  final DateTime addedAt;
+
+  const FavoriteItem({
+    required this.id,
+    required this.itemId,
+    required this.itemType,
+    required this.name,
+    required this.path,
+    required this.addedAt,
+  });
+
+  bool get isFile => itemType == 'file';
+  bool get isFolder => itemType == 'folder';
+
+  @override
+  List<Object?> get props => [id, itemId, itemType, name, path, addedAt];
+}
+
+/// Recent item entity
+class RecentItem extends Equatable {
+  final String id;
+  final String itemId;
+  final String itemType; // 'file' or 'folder'
+  final String name;
+  final String path;
+  final String? mimeType;
+  final int? size;
+  final DateTime accessedAt;
+
+  const RecentItem({
+    required this.id,
+    required this.itemId,
+    required this.itemType,
+    required this.name,
+    required this.path,
+    this.mimeType,
+    this.size,
+    required this.accessedAt,
+  });
+
+  bool get isFile => itemType == 'file';
+  bool get isFolder => itemType == 'folder';
+
+  @override
+  List<Object?> get props => [id, itemId, itemType, name, path, accessedAt];
+}

--- a/lib/core/repositories/favorites_repository.dart
+++ b/lib/core/repositories/favorites_repository.dart
@@ -1,0 +1,22 @@
+import 'package:dartz/dartz.dart';
+import '../entities/favorite_item.dart';
+
+/// Favorites repository interface
+abstract class FavoritesRepository {
+  Future<Either<FavoritesFailure, List<FavoriteItem>>> getFavorites();
+  Future<Either<FavoritesFailure, void>> addFavorite(String itemType, String itemId);
+  Future<Either<FavoritesFailure, void>> removeFavorite(String itemType, String itemId);
+}
+
+abstract class FavoritesFailure {
+  final String message;
+  const FavoritesFailure(this.message);
+}
+
+class NetworkFavoritesFailure extends FavoritesFailure {
+  const NetworkFavoritesFailure(super.message);
+}
+
+class UnknownFavoritesFailure extends FavoritesFailure {
+  const UnknownFavoritesFailure(super.message);
+}

--- a/lib/core/repositories/recent_repository.dart
+++ b/lib/core/repositories/recent_repository.dart
@@ -1,0 +1,22 @@
+import 'package:dartz/dartz.dart';
+import '../entities/favorite_item.dart';
+
+/// Recent files repository interface
+abstract class RecentRepository {
+  Future<Either<RecentFailure, List<RecentItem>>> getRecent();
+  Future<Either<RecentFailure, void>> addRecent(String itemType, String itemId);
+  Future<Either<RecentFailure, void>> clearRecent();
+}
+
+abstract class RecentFailure {
+  final String message;
+  const RecentFailure(this.message);
+}
+
+class NetworkRecentFailure extends RecentFailure {
+  const NetworkRecentFailure(super.message);
+}
+
+class UnknownRecentFailure extends RecentFailure {
+  const UnknownRecentFailure(super.message);
+}

--- a/lib/data/datasources/api_client.dart
+++ b/lib/data/datasources/api_client.dart
@@ -11,6 +11,7 @@ class ApiClient {
   static const _usernameKey = 'username';
   static const _passwordKey = 'password'; // stored for silent re-login
   static const _accessTokenKey = 'access_token';
+  static const _refreshTokenKey = 'refresh_token';
 
   final Dio _dio;
   final Logger _logger = Logger();
@@ -95,24 +96,57 @@ class ApiClient {
     _configured = _token != null;
   }
 
-  /// Try to obtain a fresh access token by calling the server login
-  /// endpoint directly with stored credentials.
+  /// Try to obtain a fresh access token. First attempts refresh token,
+  /// then falls back to full re-login with stored credentials.
   Future<bool> _silentReLogin() async {
     _isRefreshing = true;
     try {
       final prefs = await SharedPreferences.getInstance();
       final serverUrl = prefs.getString(_serverUrlKey);
+      if (serverUrl == null) return false;
+
+      final baseUrl = _normaliseUrl(serverUrl);
+
+      // 1. Try refresh token first (server expects it in JSON body)
+      final refreshToken = prefs.getString(_refreshTokenKey);
+      if (refreshToken != null && refreshToken.isNotEmpty) {
+        try {
+          final response = await Dio().post<Map<String, dynamic>>(
+            '${baseUrl}api/auth/refresh',
+            data: {'refresh_token': refreshToken},
+          );
+          final data = response.data;
+          if (data != null) {
+            final newToken = data['access_token'] as String?;
+            final newRefresh = data['refresh_token'] as String?;
+            if (newToken != null && newToken.isNotEmpty) {
+              await prefs.setString(_accessTokenKey, newToken);
+              if (newRefresh != null) {
+                await prefs.setString(_refreshTokenKey, newRefresh);
+              }
+              _token = newToken;
+              _dio.options.baseUrl = baseUrl;
+              _configured = true;
+              _logger.i('Token refresh succeeded');
+              return true;
+            }
+          }
+        } catch (_) {
+          _logger.w('Token refresh failed, falling back to re-login');
+        }
+      }
+
+      // 2. Fallback: full re-login with stored credentials
       final username = prefs.getString(_usernameKey);
       final password = prefs.getString(_passwordKey);
 
-      if (serverUrl == null || username == null || password == null) {
+      if (username == null || password == null) {
         _logger.w('Cannot re-login: missing stored credentials');
         return false;
       }
 
-      final baseUrl = _normaliseUrl(serverUrl);
       final response = await Dio().post<Map<String, dynamic>>(
-        '${baseUrl}auth/login',
+        '${baseUrl}api/auth/login',
         data: {'username': username, 'password': password},
       );
 
@@ -120,10 +154,13 @@ class ApiClient {
       if (data == null) return false;
 
       final newToken = data['access_token'] as String?;
+      final newRefresh = data['refresh_token'] as String?;
       if (newToken == null || newToken.isEmpty) return false;
 
-      // Persist and apply the fresh token
       await prefs.setString(_accessTokenKey, newToken);
+      if (newRefresh != null) {
+        await prefs.setString(_refreshTokenKey, newRefresh);
+      }
       _token = newToken;
       _dio.options.baseUrl = baseUrl;
       _configured = true;

--- a/lib/data/datasources/chunked_upload_datasource.dart
+++ b/lib/data/datasources/chunked_upload_datasource.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'api_client.dart';
+
+/// Chunked upload data source matching OxiCloud server's /api/uploads endpoint
+class ChunkedUploadDataSource {
+  final ApiClient _apiClient;
+
+  /// Default chunk size: 5 MB
+  static const int defaultChunkSize = 5 * 1024 * 1024;
+
+  ChunkedUploadDataSource(this._apiClient);
+
+  /// Initiate a chunked upload session.
+  /// POST /api/uploads
+  Future<ChunkedUploadSession> initiate({
+    required String fileName,
+    required int totalSize,
+    String? folderId,
+    String? mimeType,
+  }) async {
+    final response = await _apiClient.dio.post<Map<String, dynamic>>(
+      'api/uploads',
+      data: {
+        'file_name': fileName,
+        'total_size': totalSize,
+        if (folderId != null) 'folder_id': folderId,
+        if (mimeType != null) 'mime_type': mimeType,
+      },
+    );
+
+    final data = response.data!;
+    return ChunkedUploadSession(
+      uploadId: data['upload_id'] as String,
+      chunkSize: (data['chunk_size'] as int?) ?? defaultChunkSize,
+      totalChunks: (data['total_chunks'] as int?) ?? 0,
+    );
+  }
+
+  /// Upload a single chunk.
+  /// PATCH /api/uploads/{uploadId}
+  Future<void> uploadChunk({
+    required String uploadId,
+    required int chunkIndex,
+    required List<int> chunkData,
+    required int offset,
+    required int totalSize,
+  }) async {
+    await _apiClient.dio.patch(
+      'api/uploads/$uploadId',
+      data: Stream.fromIterable([chunkData]),
+      options: Options(
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Content-Range': 'bytes $offset-${offset + chunkData.length - 1}/$totalSize',
+        },
+      ),
+    );
+  }
+
+  /// Check upload progress.
+  /// HEAD /api/uploads/{uploadId}
+  Future<int> getUploadOffset(String uploadId) async {
+    final response = await _apiClient.dio.head('api/uploads/$uploadId');
+    final offset = response.headers.value('Upload-Offset');
+    return offset != null ? int.tryParse(offset) ?? 0 : 0;
+  }
+
+  /// Complete the upload.
+  /// POST /api/uploads/{uploadId}/complete
+  Future<Map<String, dynamic>> complete(String uploadId) async {
+    final response = await _apiClient.dio.post<Map<String, dynamic>>(
+      'api/uploads/$uploadId/complete',
+    );
+    return response.data ?? {};
+  }
+
+  /// Cancel / abort the upload.
+  /// DELETE /api/uploads/{uploadId}
+  Future<void> cancel(String uploadId) async {
+    await _apiClient.dio.delete('api/uploads/$uploadId');
+  }
+
+  /// Upload a large file using chunked upload.
+  /// Returns the created file metadata.
+  Future<Map<String, dynamic>> uploadFile({
+    required File file,
+    String? folderId,
+    void Function(int sent, int total)? onProgress,
+  }) async {
+    final totalSize = await file.length();
+    final fileName = file.path.split(Platform.pathSeparator).last;
+
+    // 1. Initiate
+    final session = await initiate(
+      fileName: fileName,
+      totalSize: totalSize,
+      folderId: folderId,
+    );
+
+    // 2. Upload chunks
+    final chunkSize = session.chunkSize;
+    final raf = await file.open(mode: FileMode.read);
+    int offset = 0;
+
+    try {
+      while (offset < totalSize) {
+        final remaining = totalSize - offset;
+        final currentChunkSize = remaining < chunkSize ? remaining : chunkSize;
+
+        await raf.setPosition(offset);
+        final chunk = await raf.read(currentChunkSize);
+
+        await uploadChunk(
+          uploadId: session.uploadId,
+          chunkIndex: offset ~/ chunkSize,
+          chunkData: chunk,
+          offset: offset,
+          totalSize: totalSize,
+        );
+
+        offset += currentChunkSize;
+        onProgress?.call(offset, totalSize);
+      }
+    } finally {
+      await raf.close();
+    }
+
+    // 3. Complete
+    return await complete(session.uploadId);
+  }
+}
+
+/// Represents an active chunked upload session
+class ChunkedUploadSession {
+  final String uploadId;
+  final int chunkSize;
+  final int totalChunks;
+
+  const ChunkedUploadSession({
+    required this.uploadId,
+    required this.chunkSize,
+    required this.totalChunks,
+  });
+}

--- a/lib/data/datasources/favorites_api_datasource.dart
+++ b/lib/data/datasources/favorites_api_datasource.dart
@@ -1,0 +1,24 @@
+import 'api_client.dart';
+
+/// API data source for favorites operations matching OxiCloud server
+class FavoritesApiDataSource {
+  final ApiClient _apiClient;
+
+  FavoritesApiDataSource(this._apiClient);
+
+  /// GET /api/favorites
+  Future<List<Map<String, dynamic>>> getFavorites() async {
+    final response = await _apiClient.dio.get('api/favorites');
+    return (response.data as List).cast<Map<String, dynamic>>();
+  }
+
+  /// POST /api/favorites/{itemType}/{itemId}
+  Future<void> addFavorite(String itemType, String itemId) async {
+    await _apiClient.dio.post('api/favorites/$itemType/$itemId');
+  }
+
+  /// DELETE /api/favorites/{itemType}/{itemId}
+  Future<void> removeFavorite(String itemType, String itemId) async {
+    await _apiClient.dio.delete('api/favorites/$itemType/$itemId');
+  }
+}

--- a/lib/data/datasources/recent_api_datasource.dart
+++ b/lib/data/datasources/recent_api_datasource.dart
@@ -1,0 +1,24 @@
+import 'api_client.dart';
+
+/// API data source for recent files matching OxiCloud server
+class RecentApiDataSource {
+  final ApiClient _apiClient;
+
+  RecentApiDataSource(this._apiClient);
+
+  /// GET /api/recent
+  Future<List<Map<String, dynamic>>> getRecent() async {
+    final response = await _apiClient.dio.get('api/recent');
+    return (response.data as List).cast<Map<String, dynamic>>();
+  }
+
+  /// POST /api/recent/{itemType}/{itemId}
+  Future<void> addRecent(String itemType, String itemId) async {
+    await _apiClient.dio.post('api/recent/$itemType/$itemId');
+  }
+
+  /// DELETE /api/recent/clear
+  Future<void> clearRecent() async {
+    await _apiClient.dio.delete('api/recent/clear');
+  }
+}

--- a/lib/data/repositories/favorites_repository_impl.dart
+++ b/lib/data/repositories/favorites_repository_impl.dart
@@ -1,0 +1,56 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+
+import '../../core/entities/favorite_item.dart';
+import '../../core/repositories/favorites_repository.dart';
+import '../datasources/favorites_api_datasource.dart';
+
+class FavoritesRepositoryImpl implements FavoritesRepository {
+  final FavoritesApiDataSource _dataSource;
+
+  FavoritesRepositoryImpl(this._dataSource);
+
+  @override
+  Future<Either<FavoritesFailure, List<FavoriteItem>>> getFavorites() async {
+    try {
+      final data = await _dataSource.getFavorites();
+      final items = data.map((d) => FavoriteItem(
+        id: d['id']?.toString() ?? '',
+        itemId: d['item_id']?.toString() ?? '',
+        itemType: d['item_type']?.toString() ?? 'file',
+        name: d['name']?.toString() ?? '',
+        path: d['path']?.toString() ?? '',
+        addedAt: DateTime.tryParse(d['created_at']?.toString() ?? '') ?? DateTime.now(),
+      )).toList();
+      return Right(items);
+    } on DioException catch (e) {
+      return Left(NetworkFavoritesFailure(e.message ?? 'Network error'));
+    } catch (e) {
+      return Left(UnknownFavoritesFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<FavoritesFailure, void>> addFavorite(String itemType, String itemId) async {
+    try {
+      await _dataSource.addFavorite(itemType, itemId);
+      return const Right(null);
+    } on DioException catch (e) {
+      return Left(NetworkFavoritesFailure(e.message ?? 'Network error'));
+    } catch (e) {
+      return Left(UnknownFavoritesFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<FavoritesFailure, void>> removeFavorite(String itemType, String itemId) async {
+    try {
+      await _dataSource.removeFavorite(itemType, itemId);
+      return const Right(null);
+    } on DioException catch (e) {
+      return Left(NetworkFavoritesFailure(e.message ?? 'Network error'));
+    } catch (e) {
+      return Left(UnknownFavoritesFailure(e.toString()));
+    }
+  }
+}

--- a/lib/data/repositories/recent_repository_impl.dart
+++ b/lib/data/repositories/recent_repository_impl.dart
@@ -1,0 +1,58 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+
+import '../../core/entities/favorite_item.dart';
+import '../../core/repositories/recent_repository.dart';
+import '../datasources/recent_api_datasource.dart';
+
+class RecentRepositoryImpl implements RecentRepository {
+  final RecentApiDataSource _dataSource;
+
+  RecentRepositoryImpl(this._dataSource);
+
+  @override
+  Future<Either<RecentFailure, List<RecentItem>>> getRecent() async {
+    try {
+      final data = await _dataSource.getRecent();
+      final items = data.map((d) => RecentItem(
+        id: d['id']?.toString() ?? '',
+        itemId: d['item_id']?.toString() ?? '',
+        itemType: d['item_type']?.toString() ?? 'file',
+        name: d['name']?.toString() ?? '',
+        path: d['path']?.toString() ?? '',
+        mimeType: d['mime_type']?.toString(),
+        size: d['size'] as int?,
+        accessedAt: DateTime.tryParse(d['accessed_at']?.toString() ?? '') ?? DateTime.now(),
+      )).toList();
+      return Right(items);
+    } on DioException catch (e) {
+      return Left(NetworkRecentFailure(e.message ?? 'Network error'));
+    } catch (e) {
+      return Left(UnknownRecentFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<RecentFailure, void>> addRecent(String itemType, String itemId) async {
+    try {
+      await _dataSource.addRecent(itemType, itemId);
+      return const Right(null);
+    } on DioException catch (e) {
+      return Left(NetworkRecentFailure(e.message ?? 'Network error'));
+    } catch (e) {
+      return Left(UnknownRecentFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<RecentFailure, void>> clearRecent() async {
+    try {
+      await _dataSource.clearRecent();
+      return const Right(null);
+    } on DioException catch (e) {
+      return Left(NetworkRecentFailure(e.message ?? 'Network error'));
+    } catch (e) {
+      return Left(UnknownRecentFailure(e.toString()));
+    }
+  }
+}

--- a/lib/injection.dart
+++ b/lib/injection.dart
@@ -1,19 +1,26 @@
 import 'package:get_it/get_it.dart';
 
 import 'core/repositories/auth_repository.dart';
+import 'core/repositories/favorites_repository.dart';
 import 'core/repositories/file_browser_repository.dart';
+import 'core/repositories/recent_repository.dart';
 import 'core/repositories/search_repository.dart';
 import 'core/repositories/share_repository.dart';
 import 'core/repositories/sync_repository.dart';
 import 'core/repositories/trash_repository.dart';
 import 'data/datasources/api_client.dart';
+import 'data/datasources/chunked_upload_datasource.dart';
+import 'data/datasources/favorites_api_datasource.dart';
 import 'data/datasources/file_browser_api_datasource.dart';
+import 'data/datasources/recent_api_datasource.dart';
 import 'data/datasources/rust_bridge_datasource.dart';
 import 'data/datasources/search_api_datasource.dart';
 import 'data/datasources/share_api_datasource.dart';
 import 'data/datasources/trash_api_datasource.dart';
 import 'data/repositories/auth_repository_impl.dart';
+import 'data/repositories/favorites_repository_impl.dart';
 import 'data/repositories/file_browser_repository_impl.dart';
+import 'data/repositories/recent_repository_impl.dart';
 import 'data/repositories/search_repository_impl.dart';
 import 'data/repositories/share_repository_impl.dart';
 import 'data/repositories/sync_repository_impl.dart';
@@ -27,41 +34,47 @@ Future<void> configureDependencies() async {
   // ============================================================================
   // Data Sources
   // ============================================================================
-  
-  // Rust Bridge Data Source - connects to native Rust code
+
   getIt.registerLazySingleton<RustBridgeDataSource>(
     () => RustBridgeDataSource(),
   );
 
-  // HTTP API client for REST calls (file browser, etc.)
   getIt.registerLazySingleton<ApiClient>(
     () => ApiClient(),
   );
 
-  // File browser API data source
   getIt.registerLazySingleton<FileBrowserApiDataSource>(
     () => FileBrowserApiDataSource(getIt<ApiClient>()),
   );
 
-  // Trash API data source
   getIt.registerLazySingleton<TrashApiDataSource>(
     () => TrashApiDataSource(getIt<ApiClient>()),
   );
 
-  // Share API data source
   getIt.registerLazySingleton<ShareApiDataSource>(
     () => ShareApiDataSource(getIt<ApiClient>()),
   );
 
-  // Search API data source
   getIt.registerLazySingleton<SearchApiDataSource>(
     () => SearchApiDataSource(getIt<ApiClient>()),
+  );
+
+  getIt.registerLazySingleton<FavoritesApiDataSource>(
+    () => FavoritesApiDataSource(getIt<ApiClient>()),
+  );
+
+  getIt.registerLazySingleton<RecentApiDataSource>(
+    () => RecentApiDataSource(getIt<ApiClient>()),
+  );
+
+  getIt.registerLazySingleton<ChunkedUploadDataSource>(
+    () => ChunkedUploadDataSource(getIt<ApiClient>()),
   );
 
   // ============================================================================
   // Repositories
   // ============================================================================
-  
+
   getIt.registerLazySingleton<AuthRepository>(
     () => AuthRepositoryImpl(
       getIt<RustBridgeDataSource>(),
@@ -87,6 +100,14 @@ Future<void> configureDependencies() async {
 
   getIt.registerLazySingleton<SearchRepository>(
     () => SearchRepositoryImpl(getIt<SearchApiDataSource>()),
+  );
+
+  getIt.registerLazySingleton<FavoritesRepository>(
+    () => FavoritesRepositoryImpl(getIt<FavoritesApiDataSource>()),
+  );
+
+  getIt.registerLazySingleton<RecentRepository>(
+    () => RecentRepositoryImpl(getIt<RecentApiDataSource>()),
   );
 
   // ============================================================================

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,9 @@ import 'dart:io';
 import 'src/rust/frb_generated.dart';
 import 'injection.dart';
 import 'core/repositories/auth_repository.dart';
+import 'core/repositories/favorites_repository.dart';
 import 'core/repositories/file_browser_repository.dart';
+import 'core/repositories/recent_repository.dart';
 import 'core/repositories/search_repository.dart';
 import 'core/repositories/share_repository.dart';
 import 'core/repositories/sync_repository.dart';
@@ -17,6 +19,8 @@ import 'presentation/blocs/file_browser/file_browser_bloc.dart';
 import 'presentation/blocs/trash/trash_bloc.dart';
 import 'presentation/blocs/share/share_bloc.dart';
 import 'presentation/blocs/search/search_bloc.dart';
+import 'presentation/blocs/favorites/favorites_bloc.dart';
+import 'presentation/blocs/recent/recent_bloc.dart';
 import 'presentation/app.dart';
 import 'platform/desktop_window.dart';
 import 'platform/system_tray_service.dart';
@@ -101,6 +105,12 @@ class OxiCloudAppWrapper extends StatelessWidget {
         ),
         BlocProvider(
           create: (_) => SearchBloc(getIt<SearchRepository>()),
+        ),
+        BlocProvider(
+          create: (_) => FavoritesBloc(getIt<FavoritesRepository>()),
+        ),
+        BlocProvider(
+          create: (_) => RecentBloc(getIt<RecentRepository>()),
         ),
         RepositoryProvider<SyncRepository>(
           create: (_) => getIt<SyncRepository>(),

--- a/lib/presentation/app.dart
+++ b/lib/presentation/app.dart
@@ -8,8 +8,10 @@ import '../main.dart' show navigatorKey;
 import 'blocs/auth/auth_bloc.dart';
 import 'blocs/settings/settings_bloc.dart';
 import 'pages/activity_page.dart';
+import 'pages/favorites_page.dart';
 import 'pages/home_page.dart';
 import 'pages/login_page.dart';
+import 'pages/recent_page.dart';
 import 'pages/settings_page.dart';
 import 'pages/selective_sync_page.dart';
 import 'pages/file_browser_page.dart';
@@ -104,6 +106,16 @@ class OxiCloudApp extends StatelessWidget {
       case '/activity':
         return MaterialPageRoute(
           builder: (_) => const ActivityPage(),
+        );
+
+      case '/favorites':
+        return MaterialPageRoute(
+          builder: (_) => const FavoritesPage(),
+        );
+
+      case '/recent':
+        return MaterialPageRoute(
+          builder: (_) => const RecentPage(),
         );
 
       default:

--- a/lib/presentation/blocs/favorites/favorites_bloc.dart
+++ b/lib/presentation/blocs/favorites/favorites_bloc.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../core/entities/favorite_item.dart';
+import '../../../core/repositories/favorites_repository.dart';
+
+// Events
+abstract class FavoritesEvent extends Equatable {
+  const FavoritesEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadFavorites extends FavoritesEvent {
+  const LoadFavorites();
+}
+
+class AddFavorite extends FavoritesEvent {
+  final String itemType;
+  final String itemId;
+  const AddFavorite({required this.itemType, required this.itemId});
+  @override
+  List<Object?> get props => [itemType, itemId];
+}
+
+class RemoveFavorite extends FavoritesEvent {
+  final String itemType;
+  final String itemId;
+  const RemoveFavorite({required this.itemType, required this.itemId});
+  @override
+  List<Object?> get props => [itemType, itemId];
+}
+
+// States
+abstract class FavoritesState extends Equatable {
+  const FavoritesState();
+  @override
+  List<Object?> get props => [];
+}
+
+class FavoritesInitial extends FavoritesState {
+  const FavoritesInitial();
+}
+
+class FavoritesLoading extends FavoritesState {
+  const FavoritesLoading();
+}
+
+class FavoritesLoaded extends FavoritesState {
+  final List<FavoriteItem> items;
+  const FavoritesLoaded(this.items);
+  @override
+  List<Object?> get props => [items];
+}
+
+class FavoritesError extends FavoritesState {
+  final String message;
+  const FavoritesError(this.message);
+  @override
+  List<Object?> get props => [message];
+}
+
+// BLoC
+class FavoritesBloc extends Bloc<FavoritesEvent, FavoritesState> {
+  final FavoritesRepository _repository;
+
+  FavoritesBloc(this._repository) : super(const FavoritesInitial()) {
+    on<LoadFavorites>(_onLoad);
+    on<AddFavorite>(_onAdd);
+    on<RemoveFavorite>(_onRemove);
+  }
+
+  Future<void> _onLoad(LoadFavorites event, Emitter<FavoritesState> emit) async {
+    emit(const FavoritesLoading());
+    final result = await _repository.getFavorites();
+    result.fold(
+      (f) => emit(FavoritesError(f.message)),
+      (items) => emit(FavoritesLoaded(items)),
+    );
+  }
+
+  Future<void> _onAdd(AddFavorite event, Emitter<FavoritesState> emit) async {
+    await _repository.addFavorite(event.itemType, event.itemId);
+    add(const LoadFavorites());
+  }
+
+  Future<void> _onRemove(RemoveFavorite event, Emitter<FavoritesState> emit) async {
+    await _repository.removeFavorite(event.itemType, event.itemId);
+    add(const LoadFavorites());
+  }
+}

--- a/lib/presentation/blocs/recent/recent_bloc.dart
+++ b/lib/presentation/blocs/recent/recent_bloc.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../core/entities/favorite_item.dart';
+import '../../../core/repositories/recent_repository.dart';
+
+// Events
+abstract class RecentEvent extends Equatable {
+  const RecentEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadRecent extends RecentEvent {
+  const LoadRecent();
+}
+
+class ClearRecentRequested extends RecentEvent {
+  const ClearRecentRequested();
+}
+
+// States
+abstract class RecentState extends Equatable {
+  const RecentState();
+  @override
+  List<Object?> get props => [];
+}
+
+class RecentInitial extends RecentState {
+  const RecentInitial();
+}
+
+class RecentLoading extends RecentState {
+  const RecentLoading();
+}
+
+class RecentLoaded extends RecentState {
+  final List<RecentItem> items;
+  const RecentLoaded(this.items);
+  @override
+  List<Object?> get props => [items];
+}
+
+class RecentError extends RecentState {
+  final String message;
+  const RecentError(this.message);
+  @override
+  List<Object?> get props => [message];
+}
+
+// BLoC
+class RecentBloc extends Bloc<RecentEvent, RecentState> {
+  final RecentRepository _repository;
+
+  RecentBloc(this._repository) : super(const RecentInitial()) {
+    on<LoadRecent>(_onLoad);
+    on<ClearRecentRequested>(_onClear);
+  }
+
+  Future<void> _onLoad(LoadRecent event, Emitter<RecentState> emit) async {
+    emit(const RecentLoading());
+    final result = await _repository.getRecent();
+    result.fold(
+      (f) => emit(RecentError(f.message)),
+      (items) => emit(RecentLoaded(items)),
+    );
+  }
+
+  Future<void> _onClear(ClearRecentRequested event, Emitter<RecentState> emit) async {
+    await _repository.clearRecent();
+    add(const LoadRecent());
+  }
+}

--- a/lib/presentation/pages/favorites_page.dart
+++ b/lib/presentation/pages/favorites_page.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../core/entities/favorite_item.dart';
+import '../blocs/favorites/favorites_bloc.dart';
+import '../theme/oxicloud_colors.dart';
+
+class FavoritesPage extends StatefulWidget {
+  const FavoritesPage({super.key});
+
+  @override
+  State<FavoritesPage> createState() => _FavoritesPageState();
+}
+
+class _FavoritesPageState extends State<FavoritesPage> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<FavoritesBloc>().add(const LoadFavorites());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Favorites'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => context.read<FavoritesBloc>().add(const LoadFavorites()),
+          ),
+        ],
+      ),
+      body: BlocBuilder<FavoritesBloc, FavoritesState>(
+        builder: (context, state) {
+          if (state is FavoritesLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is FavoritesError) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error_outline, size: 48, color: OxiColors.error),
+                  const SizedBox(height: 16),
+                  Text(state.message),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => context.read<FavoritesBloc>().add(const LoadFavorites()),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          if (state is FavoritesLoaded) {
+            if (state.items.isEmpty) {
+              return Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.star_outline, size: 64, color: OxiColors.textSecondary),
+                    const SizedBox(height: 16),
+                    Text(
+                      'No favorites yet',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: OxiColors.textSecondary,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Star files and folders to find them quickly',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: OxiColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }
+
+            return ListView.separated(
+              itemCount: state.items.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final item = state.items[index];
+                return _buildFavoriteTile(context, item);
+              },
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+
+  Widget _buildFavoriteTile(BuildContext context, FavoriteItem item) {
+    return ListTile(
+      leading: Icon(
+        item.isFolder ? Icons.folder : Icons.insert_drive_file,
+        color: item.isFolder ? OxiColors.primary : OxiColors.textSecondary,
+      ),
+      title: Text(item.name, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        item.path,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(fontSize: 12, color: OxiColors.textSecondary),
+      ),
+      trailing: IconButton(
+        icon: const Icon(Icons.star, color: Colors.amber),
+        onPressed: () {
+          context.read<FavoritesBloc>().add(
+            RemoveFavorite(itemType: item.itemType, itemId: item.itemId),
+          );
+        },
+        tooltip: 'Remove from favorites',
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/recent_page.dart
+++ b/lib/presentation/pages/recent_page.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../core/entities/favorite_item.dart';
+import '../blocs/recent/recent_bloc.dart';
+import '../theme/oxicloud_colors.dart';
+
+class RecentPage extends StatefulWidget {
+  const RecentPage({super.key});
+
+  @override
+  State<RecentPage> createState() => _RecentPageState();
+}
+
+class _RecentPageState extends State<RecentPage> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<RecentBloc>().add(const LoadRecent());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Recent'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => context.read<RecentBloc>().add(const LoadRecent()),
+          ),
+          PopupMenuButton<String>(
+            onSelected: (value) {
+              if (value == 'clear') {
+                showDialog(
+                  context: context,
+                  builder: (ctx) => AlertDialog(
+                    title: const Text('Clear Recent'),
+                    content: const Text('Clear all recent file history?'),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx),
+                        child: const Text('Cancel'),
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          Navigator.pop(ctx);
+                          context.read<RecentBloc>().add(const ClearRecentRequested());
+                        },
+                        child: const Text('Clear'),
+                      ),
+                    ],
+                  ),
+                );
+              }
+            },
+            itemBuilder: (_) => [
+              const PopupMenuItem(value: 'clear', child: Text('Clear history')),
+            ],
+          ),
+        ],
+      ),
+      body: BlocBuilder<RecentBloc, RecentState>(
+        builder: (context, state) {
+          if (state is RecentLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is RecentError) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error_outline, size: 48, color: OxiColors.error),
+                  const SizedBox(height: 16),
+                  Text(state.message),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => context.read<RecentBloc>().add(const LoadRecent()),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          if (state is RecentLoaded) {
+            if (state.items.isEmpty) {
+              return Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.history, size: 64, color: OxiColors.textSecondary),
+                    const SizedBox(height: 16),
+                    Text(
+                      'No recent files',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: OxiColors.textSecondary,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Files you open will appear here',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: OxiColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }
+
+            return ListView.separated(
+              itemCount: state.items.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final item = state.items[index];
+                return _buildRecentTile(item);
+              },
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+
+  Widget _buildRecentTile(RecentItem item) {
+    return ListTile(
+      leading: Icon(
+        item.isFolder ? Icons.folder : Icons.insert_drive_file,
+        color: item.isFolder ? OxiColors.primary : OxiColors.textSecondary,
+      ),
+      title: Text(item.name, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        item.path,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(fontSize: 12, color: OxiColors.textSecondary),
+      ),
+      trailing: Text(
+        _formatTimestamp(item.accessedAt),
+        style: TextStyle(fontSize: 11, color: OxiColors.textSecondary),
+      ),
+    );
+  }
+
+  String _formatTimestamp(DateTime time) {
+    final diff = DateTime.now().difference(time);
+    if (diff.inMinutes < 1) return 'Just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    if (diff.inDays < 7) return '${diff.inDays}d ago';
+    return '${time.day}/${time.month}/${time.year}';
+  }
+}

--- a/lib/presentation/shell/adaptive_shell.dart
+++ b/lib/presentation/shell/adaptive_shell.dart
@@ -6,8 +6,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../core/repositories/sync_repository.dart';
 import '../blocs/settings/settings_bloc.dart';
 import '../blocs/sync/sync_bloc.dart';
+import '../pages/favorites_page.dart';
 import '../pages/file_browser_page.dart';
 import '../pages/home_page.dart';
+import '../pages/recent_page.dart';
 import '../pages/search_page.dart';
 import '../pages/settings_page.dart';
 import '../pages/shares_page.dart';
@@ -19,7 +21,7 @@ import '../theme/oxicloud_colors.dart';
 // =============================================================================
 
 /// Logical destinations used by both desktop and mobile shells.
-enum ShellDestination { home, files, search, shares, trash, settings }
+enum ShellDestination { home, files, favorites, recent, search, shares, trash, settings }
 
 // =============================================================================
 // ShellScope — lets child pages trigger tab switches
@@ -66,12 +68,26 @@ class _AdaptiveShellState extends State<AdaptiveShell> {
       Platform.isWindows || Platform.isLinux || Platform.isMacOS;
 
   void _onNavigate(ShellDestination dest) {
-    // On mobile, Trash is not in the bottom nav → push as standalone page
-    if (!_isDesktop && dest == ShellDestination.trash) {
-      Navigator.of(context).push(
-        MaterialPageRoute(builder: (_) => const TrashPage()),
-      );
-      return;
+    // On mobile, some pages are not in bottom nav → push as standalone
+    if (!_isDesktop) {
+      if (dest == ShellDestination.trash) {
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const TrashPage()),
+        );
+        return;
+      }
+      if (dest == ShellDestination.favorites) {
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const FavoritesPage()),
+        );
+        return;
+      }
+      if (dest == ShellDestination.recent) {
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const RecentPage()),
+        );
+        return;
+      }
     }
     setState(() => _selected = dest);
   }
@@ -80,10 +96,12 @@ class _AdaptiveShellState extends State<AdaptiveShell> {
   late final List<Widget> _pages = [
     const HomePage(),             // 0 — home
     const FileBrowserPage(),      // 1 — files
-    const SearchPage(),           // 2 — search
-    const SharesPage(),           // 3 — shares
-    const TrashPage(),            // 4 — trash  (desktop tab, mobile push)
-    BlocProvider(                  // 5 — settings
+    const FavoritesPage(),        // 2 — favorites
+    const RecentPage(),           // 3 — recent
+    const SearchPage(),           // 4 — search
+    const SharesPage(),           // 5 — shares
+    const TrashPage(),            // 6 — trash  (desktop tab, mobile push)
+    BlocProvider(                  // 7 — settings
       create: (ctx) => SettingsBloc(ctx.read<SyncRepository>()),
       child: const SettingsPage(),
     ),
@@ -178,6 +196,16 @@ class _DesktopLayout extends StatelessWidget {
                 label: Text('Files'),
               ),
               NavigationRailDestination(
+                icon: Icon(Icons.star_outline),
+                selectedIcon: Icon(Icons.star),
+                label: Text('Favorites'),
+              ),
+              NavigationRailDestination(
+                icon: Icon(Icons.history_outlined),
+                selectedIcon: Icon(Icons.history),
+                label: Text('Recent'),
+              ),
+              NavigationRailDestination(
                 icon: Icon(Icons.search),
                 selectedIcon: Icon(Icons.search),
                 label: Text('Search'),
@@ -230,7 +258,7 @@ class _MobileLayout extends StatelessWidget {
     required this.pages,
   });
 
-  // Mobile shows 5 destinations (no Trash — accessed via Home quick actions)
+  // Mobile shows 5 destinations (Trash, Favorites, Recent accessed via Home)
   static const _navDests = [
     ShellDestination.home,
     ShellDestination.files,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,6 +39,9 @@ chrono = { version = "0.4", features = ["serde"] }
 # UUID generation
 uuid = { version = "1.20", features = ["v4", "serde"] }
 
+# URL encoding
+percent-encoding = "2.3"
+
 # Error handling
 thiserror = "2.0"
 anyhow = "1.0"

--- a/rust/src/application/auth_service.rs
+++ b/rust/src/application/auth_service.rs
@@ -24,16 +24,14 @@ impl AuthService {
             session: Arc::new(RwLock::new(None)),
         }
     }
-    
+
     /// Login with credentials
     pub async fn login(&self, credentials: AuthCredentials) -> Result<AuthResult, AuthError> {
-        // Validate credentials
         credentials.validate()
-            .map_err(|e| AuthError::InvalidCredentials)?;
-        
-        // Make login request to server
+            .map_err(|_e| AuthError::InvalidCredentials)?;
+
         let client = reqwest::Client::new();
-        
+
         let response = client
             .post(format!("{}/api/auth/login", credentials.server_url))
             .json(&serde_json::json!({
@@ -43,58 +41,79 @@ impl AuthService {
             .send()
             .await
             .map_err(|e| AuthError::NetworkError(e.to_string()))?;
-        
+
         if !response.status().is_success() {
             return Err(AuthError::InvalidCredentials);
         }
-        
+
         let login_response: LoginResponse = response.json().await
             .map_err(|e| AuthError::NetworkError(format!("Invalid response: {}", e)))?;
-        
-        // Get server info
-        let server_info = self.fetch_server_info(&credentials.server_url, &login_response.access_token).await?;
-        
+
+        let user_id = login_response.user.id.clone();
+        let username = login_response.user.username.clone();
+        let quota_total = login_response.user.storage_quota_bytes;
+        let quota_used = login_response.user.storage_used_bytes;
+
+        // Compute expires_at from expires_in (seconds from now)
+        let expires_at = login_response.expires_in.map(|secs| {
+            Utc::now() + chrono::Duration::seconds(secs)
+        });
+
+        // Get server version info
+        let server_info = self.fetch_server_info(
+            &credentials.server_url,
+            &login_response.access_token,
+            quota_total,
+            quota_used,
+        ).await?;
+
         // Create session
         let session = AuthSession {
-            user_id: login_response.user_id.clone(),
-            username: credentials.username.clone(),
+            user_id: user_id.clone(),
+            username: username.clone(),
             access_token: login_response.access_token.clone(),
             refresh_token: login_response.refresh_token,
-            expires_at: login_response.expires_at.map(|ts| {
-                chrono::DateTime::from_timestamp(ts, 0)
-                    .unwrap_or_else(|| Utc::now())
-            }),
+            expires_at,
             server_info: server_info.clone(),
             created_at: Utc::now(),
         };
-        
+
         // Save session
         self.storage.save_session(&session).await
             .map_err(|e| AuthError::StorageError(e.to_string()))?;
-        
+
         *self.session.write().await = Some(session);
-        
+
         Ok(AuthResult {
             success: true,
-            user_id: login_response.user_id,
-            username: credentials.username,
+            user_id,
+            username,
             server_info,
             access_token: login_response.access_token,
         })
     }
-    
+
     /// Logout
     pub async fn logout(&self) {
-        // Clear stored session
+        // Try to call server logout endpoint
+        if let Some(session) = self.session.read().await.as_ref() {
+            let client = reqwest::Client::new();
+            client
+                .post(format!("{}/api/auth/logout", session.server_info.url))
+                .header("Authorization", format!("Bearer {}", session.access_token))
+                .send()
+                .await
+                .ok();
+        }
+
         self.storage.clear_session().await.ok();
         *self.session.write().await = None;
-        
+
         tracing::info!("User logged out");
     }
-    
+
     /// Check if user is logged in
     pub async fn is_logged_in(&self) -> bool {
-        // Try to load session from storage if not in memory
         if self.session.read().await.is_none() {
             if let Ok(Some(session)) = self.storage.load_session().await {
                 if !session.is_expired() {
@@ -104,143 +123,169 @@ impl AuthService {
             }
             return false;
         }
-        
+
         let session = self.session.read().await;
         session.as_ref().map(|s| !s.is_expired()).unwrap_or(false)
     }
-    
+
     /// Get current server info
     pub async fn get_server_info(&self) -> Option<ServerInfo> {
         self.session.read().await
             .as_ref()
             .map(|s| s.server_info.clone())
     }
-    
+
     /// Get current session
     pub async fn get_session(&self) -> Option<AuthSession> {
         self.session.read().await.clone()
     }
-    
+
     /// Refresh token if needed
     pub async fn refresh_if_needed(&self) -> Result<(), AuthError> {
         let session = self.session.read().await.clone();
-        
+
         if let Some(session) = session {
             if session.needs_refresh() {
                 self.refresh_token(&session).await?;
             }
         }
-        
+
         Ok(())
     }
-    
+
     /// Refresh the access token
     async fn refresh_token(&self, session: &AuthSession) -> Result<(), AuthError> {
         let refresh_token = session.refresh_token.as_ref()
             .ok_or_else(|| AuthError::RefreshFailed("No refresh token".to_string()))?;
-        
+
         let client = reqwest::Client::new();
-        
+
+        // Server expects refresh_token in JSON body (not in Authorization header)
         let response = client
             .post(format!("{}/api/auth/refresh", session.server_info.url))
-            .header("Authorization", format!("Bearer {}", refresh_token))
+            .json(&serde_json::json!({
+                "refresh_token": refresh_token,
+            }))
             .send()
             .await
             .map_err(|e| AuthError::NetworkError(e.to_string()))?;
-        
+
         if !response.status().is_success() {
             return Err(AuthError::RefreshFailed("Refresh request failed".to_string()));
         }
-        
+
         let refresh_response: RefreshResponse = response.json().await
             .map_err(|e| AuthError::NetworkError(format!("Invalid response: {}", e)))?;
-        
-        // Update session
+
         let mut updated_session = session.clone();
         updated_session.access_token = refresh_response.access_token;
         if let Some(new_refresh) = refresh_response.refresh_token {
             updated_session.refresh_token = Some(new_refresh);
         }
-        updated_session.expires_at = refresh_response.expires_at.map(|ts| {
-            chrono::DateTime::from_timestamp(ts, 0)
-                .unwrap_or_else(|| Utc::now())
+        updated_session.expires_at = refresh_response.expires_in.map(|secs| {
+            Utc::now() + chrono::Duration::seconds(secs)
         });
-        
-        // Save updated session
+
         self.storage.save_session(&updated_session).await
             .map_err(|e| AuthError::StorageError(e.to_string()))?;
-        
+
         *self.session.write().await = Some(updated_session);
-        
+
         tracing::info!("Token refreshed successfully");
         Ok(())
     }
-    
-    /// Fetch server info
-    async fn fetch_server_info(&self, server_url: &str, token: &str) -> Result<ServerInfo, AuthError> {
+
+    /// Fetch server info by combining /api/version + quota from login response
+    async fn fetch_server_info(
+        &self,
+        server_url: &str,
+        token: &str,
+        quota_total: u64,
+        quota_used: u64,
+    ) -> Result<ServerInfo, AuthError> {
         let client = reqwest::Client::new();
-        
-        let response = client
-            .get(format!("{}/api/server/info", server_url))
+
+        // Get server version from /api/version (public endpoint)
+        let version_response = client
+            .get(format!("{}/api/version", server_url))
+            .send()
+            .await;
+
+        let (version, name) = match version_response {
+            Ok(resp) if resp.status().is_success() => {
+                let info: VersionResponse = resp.json().await
+                    .unwrap_or(VersionResponse {
+                        name: "OxiCloud".to_string(),
+                        version: "unknown".to_string(),
+                    });
+                (info.version, info.name)
+            }
+            _ => ("unknown".to_string(), "OxiCloud".to_string()),
+        };
+
+        // Check server capabilities via /api/uploads (HEAD) for chunked upload support
+        let supports_chunked = client
+            .head(format!("{}/api/uploads", server_url))
             .header("Authorization", format!("Bearer {}", token))
             .send()
             .await
-            .map_err(|e| AuthError::NetworkError(e.to_string()))?;
-        
-        if !response.status().is_success() {
-            // Return default info if endpoint doesn't exist
-            return Ok(ServerInfo {
-                url: server_url.to_string(),
-                version: "unknown".to_string(),
-                name: "OxiCloud".to_string(),
-                webdav_url: format!("{}/dav", server_url),
-                quota_total: 10 * 1024 * 1024 * 1024, // 10GB default
-                quota_used: 0,
-                supports_delta_sync: false,
-                supports_chunked_upload: true,
-            });
-        }
-        
-        let info: ServerInfoResponse = response.json().await
-            .map_err(|e| AuthError::NetworkError(format!("Invalid response: {}", e)))?;
-        
+            .map(|r| r.status() != reqwest::StatusCode::NOT_FOUND)
+            .unwrap_or(true);
+
         Ok(ServerInfo {
             url: server_url.to_string(),
-            version: info.version,
-            name: info.name,
-            webdav_url: info.webdav_url.unwrap_or_else(|| format!("{}/dav", server_url)),
-            quota_total: info.quota_total,
-            quota_used: info.quota_used,
-            supports_delta_sync: info.supports_delta_sync.unwrap_or(false),
-            supports_chunked_upload: info.supports_chunked_upload.unwrap_or(true),
+            version,
+            name,
+            webdav_url: format!("{}/webdav", server_url),
+            quota_total,
+            quota_used,
+            supports_delta_sync: false,
+            supports_chunked_upload: supports_chunked,
         })
     }
 }
 
-// API response types
+// ============================================================================
+// API response types matching OxiCloud server format
+// ============================================================================
 
+/// User info in login response
 #[derive(serde::Deserialize)]
-struct LoginResponse {
-    user_id: String,
-    access_token: String,
-    refresh_token: Option<String>,
-    expires_at: Option<i64>,
+struct LoginUserDto {
+    id: String,
+    username: String,
+    #[serde(default)]
+    email: String,
+    #[serde(default)]
+    role: String,
+    #[serde(default)]
+    storage_quota_bytes: u64,
+    #[serde(default)]
+    storage_used_bytes: u64,
 }
 
+/// Login response from POST /api/auth/login
+#[derive(serde::Deserialize)]
+struct LoginResponse {
+    user: LoginUserDto,
+    access_token: String,
+    refresh_token: Option<String>,
+    #[serde(default)]
+    token_type: String,
+    expires_in: Option<i64>,
+}
+
+/// Refresh response from POST /api/auth/refresh
 #[derive(serde::Deserialize)]
 struct RefreshResponse {
     access_token: String,
     refresh_token: Option<String>,
-    expires_at: Option<i64>,
+    expires_in: Option<i64>,
 }
 
+/// Version response from GET /api/version
 #[derive(serde::Deserialize)]
-struct ServerInfoResponse {
-    version: String,
+struct VersionResponse {
     name: String,
-    webdav_url: Option<String>,
-    quota_total: u64,
-    quota_used: u64,
-    supports_delta_sync: Option<bool>,
-    supports_chunked_upload: Option<bool>,
+    version: String,
 }

--- a/rust/src/infrastructure/webdav_client.rs
+++ b/rust/src/infrastructure/webdav_client.rs
@@ -454,11 +454,41 @@ struct PartialRemoteItem {
 
 impl PartialRemoteItem {
     fn into_remote_item(self) -> Option<RemoteItem> {
-        let path = self.path?;
+        let raw_path = self.path?;
+
+        // Strip /webdav prefix from href paths returned by OxiCloud server
+        let path = if raw_path.starts_with("/webdav") {
+            raw_path.strip_prefix("/webdav").unwrap_or(&raw_path).to_string()
+        } else {
+            raw_path
+        };
+
+        // Ensure path starts with /
+        let path = if path.is_empty() || path == "/" {
+            "/".to_string()
+        } else if !path.starts_with('/') {
+            format!("/{}", path)
+        } else {
+            path
+        };
+
+        // Clean trailing slashes for consistency (except root)
+        let path = if path.len() > 1 {
+            path.trim_end_matches('/').to_string()
+        } else {
+            path
+        };
+
+        // URL-decode percent-encoded characters
+        let path = percent_encoding::percent_decode_str(&path)
+            .decode_utf8()
+            .map(|s| s.to_string())
+            .unwrap_or(path);
+
         let name = self.name.unwrap_or_else(|| {
             path.rsplit('/').next().unwrap_or(&path).to_string()
         });
-        
+
         Some(RemoteItem {
             id: uuid::Uuid::new_v4().to_string(),
             path,


### PR DESCRIPTION
…ploads

Server API Compatibility Fixes:
- Fix auth_service.rs login response parsing: server returns nested {user: {id, username, ...}, access_token, refresh_token, expires_in} instead of flat {user_id, access_token, expires_at}
- Fix server info: use GET /api/version (public) instead of non-existent /api/server/info, get quota from login response
- Fix WebDAV URL: server uses /webdav/ path, strip prefix from PROPFIND href responses and URL-decode percent-encoded paths
- Fix token refresh: send refresh_token in JSON body instead of Authorization header (matching server's POST /api/auth/refresh)
- Fix Flutter API client: try refresh_token first on 401, then fallback to full re-login with stored credentials
- Add percent-encoding crate for URL decoding

New Features:
- Favorites: full stack (entity, repository, datasource, BLoC, page) matching server's GET/POST/DELETE /api/favorites endpoints
- Recent Files: full stack matching server's /api/recent endpoints with clear history support
- Chunked Uploads: datasource matching server's /api/uploads endpoints (initiate, upload chunks, complete, cancel)
- Updated AdaptiveShell: Favorites + Recent in desktop nav rail, accessible as push pages on mobile
- Updated DI container with all new data sources and repositories
- Wired FavoritesBloc and RecentBloc in main.dart providers
- Added /favorites and /recent routes

https://claude.ai/code/session_01HERPrNUrexnYjvUmm9wSfL