### PR TITLE
fix: downgrade ffigen to ^14.0.1 for Dart 3.6.2 compat and add Window…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,65 @@ jobs:
           flutter build apk --debug
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+
+  # ── Build Windows ─────────────────────────────────────────────────────
+  build-windows:
+    needs: analyze
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/target
+          key: ci-windows-rust-${{ hashFiles('rust/Cargo.lock') }}
+
+      - name: Build
+        run: |
+          flutter pub get
+          flutter build windows --release
+
+  # ── Build macOS ──────────────────────────────────────────────────────
+  build-macos:
+    needs: analyze
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/target
+          key: ci-macos-rust-${{ hashFiles('rust/Cargo.lock') }}
+
+      - name: Build
+        run: |
+          flutter pub get
+          flutter build macos --release

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,7 @@ dev_dependencies:
   json_serializable: ^6.7.1
   mocktail: ^1.0.4
   bloc_test: ^10.0.0
-  ffigen: ^20.1.1
+  ffigen: ^14.0.1
 
 flutter:
   generate: true


### PR DESCRIPTION
…s/macOS CI builds

- ffigen ^20.1.1 requires Dart SDK >=3.8.0 which is incompatible with Flutter 3.27.4 (Dart 3.6.2). Downgraded to ^14.0.1.
- Added build-windows and build-macos jobs to CI pipeline, matching the existing release pipeline structure.

https://claude.ai/code/session_01HERPrNUrexnYjvUmm9wSfL