### PR TITLE
fix: upgrade to Flutter 3.41.2 and fix multiple bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: '3.27.4'
+  FLUTTER_VERSION: '3.41.2'
 
 jobs:
   # ── Analyze & Test ─────────────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ permissions:
   contents: write
 
 env:
-  FLUTTER_VERSION: '3.27.4'
+  FLUTTER_VERSION: '3.41.2'
   RUST_TOOLCHAIN: 'stable'
 
 jobs:

--- a/lib/core/errors/failures.dart
+++ b/lib/core/errors/failures.dart
@@ -15,69 +15,6 @@ abstract class Failure extends Equatable {
 }
 
 // =============================================================================
-// Auth failures
-// =============================================================================
-
-/// Base class for authentication-related failures.
-abstract class AuthFailure extends Failure {
-  const AuthFailure(super.message, {super.code});
-}
-
-class InvalidCredentialsFailure extends AuthFailure {
-  const InvalidCredentialsFailure()
-      : super('Invalid username or password', code: 'INVALID_CREDENTIALS');
-}
-
-class ServerUnreachableFailure extends AuthFailure {
-  const ServerUnreachableFailure(String detail)
-      : super('Server unreachable: $detail', code: 'SERVER_UNREACHABLE');
-}
-
-class NetworkFailure extends AuthFailure {
-  const NetworkFailure(String detail)
-      : super('Network error: $detail', code: 'NETWORK_ERROR');
-}
-
-class UnknownAuthFailure extends AuthFailure {
-  const UnknownAuthFailure(String detail)
-      : super(detail, code: 'UNKNOWN_AUTH');
-}
-
-// =============================================================================
-// Sync failures
-// =============================================================================
-
-/// Base class for synchronization-related failures.
-abstract class SyncFailure extends Failure {
-  const SyncFailure(super.message, {super.code});
-}
-
-class NotInitializedFailure extends SyncFailure {
-  const NotInitializedFailure()
-      : super('Sync engine not initialized', code: 'NOT_INITIALIZED');
-}
-
-class NotAuthenticatedFailure extends SyncFailure {
-  const NotAuthenticatedFailure()
-      : super('Not authenticated', code: 'NOT_AUTHENTICATED');
-}
-
-class NetworkSyncFailure extends SyncFailure {
-  const NetworkSyncFailure(String detail)
-      : super('Network error: $detail', code: 'NETWORK_SYNC');
-}
-
-class StorageSyncFailure extends SyncFailure {
-  const StorageSyncFailure(String detail)
-      : super('Storage error: $detail', code: 'STORAGE_SYNC');
-}
-
-class UnknownSyncFailure extends SyncFailure {
-  const UnknownSyncFailure(String detail)
-      : super(detail, code: 'UNKNOWN_SYNC');
-}
-
-// =============================================================================
 // File browser failures
 // =============================================================================
 

--- a/lib/data/datasources/api_client.dart
+++ b/lib/data/datasources/api_client.dart
@@ -63,6 +63,9 @@ class ApiClient {
   /// The underlying [Dio] instance (pre-configured with base URL & auth).
   Dio get dio => _dio;
 
+  /// The configured base URL (empty string if not yet configured).
+  String get baseUrl => _baseUrl ?? '';
+
   /// Whether the client has a valid (non-null) access token.
   bool get isAuthenticated => _token != null;
 

--- a/lib/data/datasources/rust_bridge_datasource.dart
+++ b/lib/data/datasources/rust_bridge_datasource.dart
@@ -257,10 +257,12 @@ class RustBridgeDataSource {
 
   Future<void> updateConfig(SyncConfigDto config) async {
     _ensureInitialized();
+    final appDir = await getApplicationSupportDirectory();
+    final dbPath = '${appDir.path}/oxicloud.db';
     await rust.updateConfig(
       config: SyncConfig(
         syncFolder: config.syncFolder,
-        databasePath: '',
+        databasePath: dbPath,
         syncIntervalSeconds: config.syncIntervalSeconds,
         maxUploadSpeedKbps: config.maxUploadSpeedKbps,
         maxDownloadSpeedKbps: config.maxDownloadSpeedKbps,

--- a/lib/data/repositories/sync_repository_impl.dart
+++ b/lib/data/repositories/sync_repository_impl.dart
@@ -268,13 +268,13 @@ class SyncRepositoryImpl implements SyncRepository {
 
   ConflictType _parseConflictType(String type) {
     switch (type) {
-      case 'BothModified':
+      case 'both_modified':
         return ConflictType.bothModified;
-      case 'DeletedLocally':
+      case 'deleted_locally':
         return ConflictType.deletedLocally;
-      case 'DeletedRemotely':
+      case 'deleted_remotely':
         return ConflictType.deletedRemotely;
-      case 'TypeMismatch':
+      case 'type_mismatch':
         return ConflictType.typeMismatch;
       default:
         return ConflictType.bothModified;
@@ -284,13 +284,13 @@ class SyncRepositoryImpl implements SyncRepository {
   String _serializeResolution(ConflictResolution resolution) {
     switch (resolution) {
       case ConflictResolution.keepLocal:
-        return 'KeepLocal';
+        return 'keep_local';
       case ConflictResolution.keepRemote:
-        return 'KeepRemote';
+        return 'keep_remote';
       case ConflictResolution.keepBoth:
-        return 'KeepBoth';
+        return 'keep_both';
       case ConflictResolution.skip:
-        return 'Skip';
+        return 'skip';
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -68,7 +68,7 @@ dev_dependencies:
   json_serializable: ^6.7.1
   mocktail: ^1.0.4
   bloc_test: ^10.0.0
-  ffigen: ^14.0.1
+  ffigen: ^20.1.1
 
 flutter:
   generate: true


### PR DESCRIPTION
- Update Flutter from 3.27.4 to 3.41.2 (Dart 3.10) in CI/release pipelines
- Update SDK constraint to >=3.8.0 and restore ffigen ^20.1.1
- Add public baseUrl getter to ApiClient (was causing compilation error in batch_api_datasource.dart)
- Fix conflict type serialization mismatch: _parseConflictType expected PascalCase but RustBridgeDataSource produced snake_case
- Fix _serializeResolution producing PascalCase while _mapResolution expected snake_case
- Fix updateConfig losing databasePath (was hardcoded to empty string)
- Remove duplicate Auth/Sync failure classes from failures.dart (unused dead code that shadows the canonical definitions in repository interfaces)

https://claude.ai/code/session_01HERPrNUrexnYjvUmm9wSfL