### PR TITLE
fix: resolve flutter analyze errors and warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ rust/src/frb_generated.web.rs
 # build_runner / freezed / json_serializable
 *.g.dart
 *.freezed.dart
+# Exception: include flutter_rust_bridge generated freezed files needed for analysis
+!lib/src/rust/domain/entities/sync_item.freezed.dart
 *.mocks.dart
 *.config.dart
 

--- a/lib/data/datasources/file_browser_api_datasource.dart
+++ b/lib/data/datasources/file_browser_api_datasource.dart
@@ -81,7 +81,7 @@ class FileBrowserApiDataSource {
   /// Upload a file via multipart.
   Future<Map<String, dynamic>> uploadFile(File file, String? folderId) async {
     final formData = FormData.fromMap({
-      ?'folder_id': folderId,
+      if (folderId != null) 'folder_id': folderId,
       'file': await MultipartFile.fromFile(
         file.path,
         filename: file.uri.pathSegments.last,

--- a/lib/data/datasources/search_api_datasource.dart
+++ b/lib/data/datasources/search_api_datasource.dart
@@ -19,7 +19,7 @@ class SearchApiDataSource {
   }) async {
     final params = <String, dynamic>{
       if (query != null && query.isNotEmpty) 'query': query,
-      ?'folder_id': folderId,
+      if (folderId != null) 'folder_id': folderId,
       'limit': limit,
       'offset': offset,
     };

--- a/lib/presentation/blocs/file_browser/file_browser_event.dart
+++ b/lib/presentation/blocs/file_browser/file_browser_event.dart
@@ -18,10 +18,10 @@ class LoadFolder extends FileBrowserEvent {
 
 /// Navigate into a sub-folder.
 class NavigateToFolder extends FileBrowserEvent {
+  const NavigateToFolder({required this.folderId, required this.folderName});
+
   final String folderId;
   final String folderName;
-
-  const NavigateToFolder({required this.folderId, required this.folderName});
 
   @override
   List<Object?> get props => [folderId, folderName];
@@ -34,9 +34,9 @@ class NavigateUp extends FileBrowserEvent {
 
 /// Jump to a specific breadcrumb index.
 class NavigateToBreadcrumb extends FileBrowserEvent {
-  final int index;
-
   const NavigateToBreadcrumb(this.index);
+
+  final int index;
 
   @override
   List<Object?> get props => [index];
@@ -49,9 +49,9 @@ class RefreshFolder extends FileBrowserEvent {
 
 /// Create a new folder in the current directory.
 class CreateFolderRequested extends FileBrowserEvent {
-  final String name;
-
   const CreateFolderRequested(this.name);
+
+  final String name;
 
   @override
   List<Object?> get props => [name];
@@ -59,9 +59,9 @@ class CreateFolderRequested extends FileBrowserEvent {
 
 /// Upload a local file to the current folder.
 class UploadFileRequested extends FileBrowserEvent {
-  final File file;
-
   const UploadFileRequested(this.file);
+
+  final File file;
 
   @override
   List<Object?> get props => [file];
@@ -69,9 +69,9 @@ class UploadFileRequested extends FileBrowserEvent {
 
 /// Delete a file.
 class DeleteFileRequested extends FileBrowserEvent {
-  final String fileId;
-
   const DeleteFileRequested(this.fileId);
+
+  final String fileId;
 
   @override
   List<Object?> get props => [fileId];
@@ -79,9 +79,9 @@ class DeleteFileRequested extends FileBrowserEvent {
 
 /// Delete a folder.
 class DeleteFolderRequested extends FileBrowserEvent {
-  final String folderId;
-
   const DeleteFolderRequested(this.folderId);
+
+  final String folderId;
 
   @override
   List<Object?> get props => [folderId];
@@ -89,10 +89,10 @@ class DeleteFolderRequested extends FileBrowserEvent {
 
 /// Rename a file.
 class RenameFileRequested extends FileBrowserEvent {
+  const RenameFileRequested({required this.fileId, required this.newName});
+
   final String fileId;
   final String newName;
-
-  const RenameFileRequested({required this.fileId, required this.newName});
 
   @override
   List<Object?> get props => [fileId, newName];
@@ -100,10 +100,10 @@ class RenameFileRequested extends FileBrowserEvent {
 
 /// Rename a folder.
 class RenameFolderRequested extends FileBrowserEvent {
+  const RenameFolderRequested({required this.folderId, required this.newName});
+
   final String folderId;
   final String newName;
-
-  const RenameFolderRequested({required this.folderId, required this.newName});
 
   @override
   List<Object?> get props => [folderId, newName];
@@ -111,10 +111,10 @@ class RenameFolderRequested extends FileBrowserEvent {
 
 /// Download a file to the given path.
 class DownloadFileRequested extends FileBrowserEvent {
+  const DownloadFileRequested({required this.fileId, required this.savePath});
+
   final String fileId;
   final String savePath;
-
-  const DownloadFileRequested({required this.fileId, required this.savePath});
 
   @override
   List<Object?> get props => [fileId, savePath];
@@ -122,9 +122,9 @@ class DownloadFileRequested extends FileBrowserEvent {
 
 /// Upload a file with progress tracking (chunked upload for large files).
 class UploadFileWithProgress extends FileBrowserEvent {
-  final File file;
-
   const UploadFileWithProgress(this.file);
+
+  final File file;
 
   @override
   List<Object?> get props => [file];
@@ -132,15 +132,15 @@ class UploadFileWithProgress extends FileBrowserEvent {
 
 /// Internal event: upload progress updated.
 class UploadProgressUpdated extends FileBrowserEvent {
-  final String fileName;
-  final int bytesSent;
-  final int bytesTotal;
-
   const UploadProgressUpdated({
     required this.fileName,
     required this.bytesSent,
     required this.bytesTotal,
   });
+
+  final String fileName;
+  final int bytesSent;
+  final int bytesTotal;
 
   @override
   List<Object?> get props => [fileName, bytesSent, bytesTotal];
@@ -148,15 +148,15 @@ class UploadProgressUpdated extends FileBrowserEvent {
 
 /// Toggle favorite on a file or folder.
 class ToggleFavorite extends FileBrowserEvent {
-  final String itemId;
-  final String itemType; // 'file' or 'folder'
-  final bool isFavorite;
-
   const ToggleFavorite({
     required this.itemId,
     required this.itemType,
     required this.isFavorite,
   });
+
+  final String itemId;
+  final String itemType; // 'file' or 'folder'
+  final bool isFavorite;
 
   @override
   List<Object?> get props => [itemId, itemType, isFavorite];
@@ -164,10 +164,10 @@ class ToggleFavorite extends FileBrowserEvent {
 
 /// Batch delete multiple items.
 class BatchDeleteRequested extends FileBrowserEvent {
+  const BatchDeleteRequested({this.fileIds = const [], this.folderIds = const []});
+
   final List<String> fileIds;
   final List<String> folderIds;
-
-  const BatchDeleteRequested({this.fileIds = const [], this.folderIds = const []});
 
   @override
   List<Object?> get props => [fileIds, folderIds];
@@ -175,15 +175,15 @@ class BatchDeleteRequested extends FileBrowserEvent {
 
 /// Move items to a different folder.
 class MoveItemsRequested extends FileBrowserEvent {
-  final List<String> fileIds;
-  final List<String> folderIds;
-  final String? targetFolderId;
-
   const MoveItemsRequested({
     this.fileIds = const [],
     this.folderIds = const [],
     this.targetFolderId,
   });
+
+  final List<String> fileIds;
+  final List<String> folderIds;
+  final String? targetFolderId;
 
   @override
   List<Object?> get props => [fileIds, folderIds, targetFolderId];
@@ -191,15 +191,15 @@ class MoveItemsRequested extends FileBrowserEvent {
 
 /// Copy items to a different folder.
 class CopyItemsRequested extends FileBrowserEvent {
-  final List<String> fileIds;
-  final List<String> folderIds;
-  final String? targetFolderId;
-
   const CopyItemsRequested({
     this.fileIds = const [],
     this.folderIds = const [],
     this.targetFolderId,
   });
+
+  final List<String> fileIds;
+  final List<String> folderIds;
+  final String? targetFolderId;
 
   @override
   List<Object?> get props => [fileIds, folderIds, targetFolderId];

--- a/lib/presentation/blocs/file_browser/file_browser_state.dart
+++ b/lib/presentation/blocs/file_browser/file_browser_state.dart
@@ -23,13 +23,6 @@ class FileBrowserLoading extends FileBrowserState {
 
 /// Folder contents loaded successfully.
 class FileBrowserLoaded extends FileBrowserState {
-  final List<FolderItem> folders;
-  final List<FileItem> files;
-  final List<BreadcrumbItem> breadcrumbs;
-  final String? currentFolderId;
-  final ViewMode viewMode;
-  final bool isActionInProgress;
-
   const FileBrowserLoaded({
     required this.folders,
     required this.files,
@@ -38,6 +31,13 @@ class FileBrowserLoaded extends FileBrowserState {
     this.viewMode = ViewMode.list,
     this.isActionInProgress = false,
   });
+
+  final List<FolderItem> folders;
+  final List<FileItem> files;
+  final List<BreadcrumbItem> breadcrumbs;
+  final String? currentFolderId;
+  final ViewMode viewMode;
+  final bool isActionInProgress;
 
   /// Total items (folders + files).
   int get totalItems => folders.length + files.length;
@@ -70,9 +70,9 @@ class FileBrowserLoaded extends FileBrowserState {
 
 /// Error while loading folder.
 class FileBrowserError extends FileBrowserState {
-  final String message;
-
   const FileBrowserError(this.message);
+
+  final String message;
 
   @override
   List<Object?> get props => [message];
@@ -80,15 +80,15 @@ class FileBrowserError extends FileBrowserState {
 
 /// File upload is in progress with progress tracking.
 class FileBrowserUploadProgress extends FileBrowserState {
-  final String fileName;
-  final int bytesSent;
-  final int bytesTotal;
-
   const FileBrowserUploadProgress({
     required this.fileName,
     required this.bytesSent,
     required this.bytesTotal,
   });
+
+  final String fileName;
+  final int bytesSent;
+  final int bytesTotal;
 
   double get progress => bytesTotal > 0 ? bytesSent / bytesTotal : 0;
   int get percent => (progress * 100).round();
@@ -99,9 +99,9 @@ class FileBrowserUploadProgress extends FileBrowserState {
 
 /// Transient success message (create, rename, delete completed).
 class FileBrowserActionSuccess extends FileBrowserState {
-  final String message;
-
   const FileBrowserActionSuccess(this.message);
+
+  final String message;
 
   @override
   List<Object?> get props => [message];
@@ -109,9 +109,9 @@ class FileBrowserActionSuccess extends FileBrowserState {
 
 /// Transient error message from an action.
 class FileBrowserActionError extends FileBrowserState {
-  final String message;
-
   const FileBrowserActionError(this.message);
+
+  final String message;
 
   @override
   List<Object?> get props => [message];

--- a/lib/presentation/blocs/recent/recent_bloc.dart
+++ b/lib/presentation/blocs/recent/recent_bloc.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../core/entities/favorite_item.dart';
 import '../../../core/repositories/recent_repository.dart';
@@ -35,23 +35,21 @@ class RecentLoading extends RecentState {
 }
 
 class RecentLoaded extends RecentState {
-  final List<RecentItem> items;
   const RecentLoaded(this.items);
+  final List<RecentItem> items;
   @override
   List<Object?> get props => [items];
 }
 
 class RecentError extends RecentState {
-  final String message;
   const RecentError(this.message);
+  final String message;
   @override
   List<Object?> get props => [message];
 }
 
 // BLoC
 class RecentBloc extends Bloc<RecentEvent, RecentState> {
-  final RecentRepository _repository;
-
   RecentBloc(this._repository) : super(const RecentInitial()) {
     on<LoadRecent>(_onLoad);
     on<ClearRecentRequested>(_onClear);

--- a/lib/presentation/pages/file_browser_page.dart
+++ b/lib/presentation/pages/file_browser_page.dart
@@ -654,10 +654,11 @@ class _FileBrowserPageState extends State<FileBrowserPage> {
     );
 
     if ((confirmed ?? false) && context.mounted) {
+      final bloc = context.read<FileBrowserBloc>();
       if (isFolder) {
-        context.read<FileBrowserBloc>().add(DeleteFolderRequested(id));
+        bloc.add(DeleteFolderRequested(id));
       } else {
-        context.read<FileBrowserBloc>().add(DeleteFileRequested(id));
+        bloc.add(DeleteFileRequested(id));
       }
     }
   }

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -310,7 +310,7 @@ class _HomePageState extends State<HomePage> {
               _buildActionCard(
                 icon: Icons.folder,
                 label: 'Open Sync Folder',
-                onTap: () => _openSyncFolder(),
+                onTap: _openSyncFolder,
               ),
               _buildActionCard(
                 icon: Icons.folder_special,

--- a/lib/presentation/pages/recent_page.dart
+++ b/lib/presentation/pages/recent_page.dart
@@ -32,7 +32,7 @@ class _RecentPageState extends State<RecentPage> {
           PopupMenuButton<String>(
             onSelected: (value) {
               if (value == 'clear') {
-                showDialog(
+                showDialog<void>(
                   context: context,
                   builder: (ctx) => AlertDialog(
                     title: const Text('Clear Recent'),

--- a/lib/src/rust/domain/entities/sync_item.freezed.dart
+++ b/lib/src/rust/domain/entities/sync_item.freezed.dart
@@ -1,0 +1,197 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'sync_item.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SyncStatus {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() synced,
+    required TResult Function() pending,
+    required TResult Function() syncing,
+    required TResult Function(ConflictInfo field0) conflict,
+    required TResult Function(String field0) error,
+    required TResult Function() ignored,
+  }) {
+    return switch (this) {
+      SyncStatus_Synced() => synced(),
+      SyncStatus_Pending() => pending(),
+      SyncStatus_Syncing() => syncing(),
+      SyncStatus_Conflict(:final field0) => conflict(field0),
+      SyncStatus_Error(:final field0) => error(field0),
+      SyncStatus_Ignored() => ignored(),
+    };
+  }
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? synced,
+    TResult Function()? pending,
+    TResult Function()? syncing,
+    TResult Function(ConflictInfo field0)? conflict,
+    TResult Function(String field0)? error,
+    TResult Function()? ignored,
+    required TResult Function() orElse,
+  }) {
+    return switch (this) {
+      SyncStatus_Synced() => synced != null ? synced() : orElse(),
+      SyncStatus_Pending() => pending != null ? pending() : orElse(),
+      SyncStatus_Syncing() => syncing != null ? syncing() : orElse(),
+      SyncStatus_Conflict(:final field0) =>
+        conflict != null ? conflict(field0) : orElse(),
+      SyncStatus_Error(:final field0) =>
+        error != null ? error(field0) : orElse(),
+      SyncStatus_Ignored() => ignored != null ? ignored() : orElse(),
+    };
+  }
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(SyncStatus_Synced value) synced,
+    required TResult Function(SyncStatus_Pending value) pending,
+    required TResult Function(SyncStatus_Syncing value) syncing,
+    required TResult Function(SyncStatus_Conflict value) conflict,
+    required TResult Function(SyncStatus_Error value) error,
+    required TResult Function(SyncStatus_Ignored value) ignored,
+  }) {
+    return switch (this) {
+      SyncStatus_Synced() => synced(this as SyncStatus_Synced),
+      SyncStatus_Pending() => pending(this as SyncStatus_Pending),
+      SyncStatus_Syncing() => syncing(this as SyncStatus_Syncing),
+      SyncStatus_Conflict() => conflict(this as SyncStatus_Conflict),
+      SyncStatus_Error() => error(this as SyncStatus_Error),
+      SyncStatus_Ignored() => ignored(this as SyncStatus_Ignored),
+    };
+  }
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(SyncStatus_Synced value)? synced,
+    TResult Function(SyncStatus_Pending value)? pending,
+    TResult Function(SyncStatus_Syncing value)? syncing,
+    TResult Function(SyncStatus_Conflict value)? conflict,
+    TResult Function(SyncStatus_Error value)? error,
+    TResult Function(SyncStatus_Ignored value)? ignored,
+    required TResult Function() orElse,
+  }) {
+    return switch (this) {
+      SyncStatus_Synced() =>
+        synced != null ? synced(this as SyncStatus_Synced) : orElse(),
+      SyncStatus_Pending() =>
+        pending != null ? pending(this as SyncStatus_Pending) : orElse(),
+      SyncStatus_Syncing() =>
+        syncing != null ? syncing(this as SyncStatus_Syncing) : orElse(),
+      SyncStatus_Conflict() =>
+        conflict != null ? conflict(this as SyncStatus_Conflict) : orElse(),
+      SyncStatus_Error() =>
+        error != null ? error(this as SyncStatus_Error) : orElse(),
+      SyncStatus_Ignored() =>
+        ignored != null ? ignored(this as SyncStatus_Ignored) : orElse(),
+    };
+  }
+}
+
+/// @nodoc
+class SyncStatus_Synced extends SyncStatus {
+  const SyncStatus_Synced() : super._();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is SyncStatus_Synced;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'SyncStatus.synced()';
+}
+
+/// @nodoc
+class SyncStatus_Pending extends SyncStatus {
+  const SyncStatus_Pending() : super._();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is SyncStatus_Pending;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'SyncStatus.pending()';
+}
+
+/// @nodoc
+class SyncStatus_Syncing extends SyncStatus {
+  const SyncStatus_Syncing() : super._();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is SyncStatus_Syncing;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'SyncStatus.syncing()';
+}
+
+/// @nodoc
+class SyncStatus_Conflict extends SyncStatus {
+  const SyncStatus_Conflict(this.field0) : super._();
+
+  final ConflictInfo field0;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SyncStatus_Conflict && other.field0 == field0);
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @override
+  String toString() => 'SyncStatus.conflict(field0: $field0)';
+}
+
+/// @nodoc
+class SyncStatus_Error extends SyncStatus {
+  const SyncStatus_Error(this.field0) : super._();
+
+  final String field0;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SyncStatus_Error && other.field0 == field0);
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @override
+  String toString() => 'SyncStatus.error(field0: $field0)';
+}
+
+/// @nodoc
+class SyncStatus_Ignored extends SyncStatus {
+  const SyncStatus_Ignored() : super._();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is SyncStatus_Ignored;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'SyncStatus.ignored()';
+}


### PR DESCRIPTION
- Add missing sync_item.freezed.dart generated file (fixes SyncStatus_* type errors)
- Update .gitignore to allow the freezed file for flutter_rust_bridge entities
- Replace unsupported null-aware map entry syntax with if-guards
- Add type parameter to showDialog to fix inference warning
- Sort constructors before fields per lint rules

https://claude.ai/code/session_01HERPrNUrexnYjvUmm9wSfL