### PR TITLE
fix: add missing _repository field declaration in RecentBloc

### DIFF
--- a/lib/presentation/blocs/recent/recent_bloc.dart
+++ b/lib/presentation/blocs/recent/recent_bloc.dart
@@ -50,6 +50,8 @@ class RecentError extends RecentState {
 
 // BLoC
 class RecentBloc extends Bloc<RecentEvent, RecentState> {
+  final RecentRepository _repository;
+
   RecentBloc(this._repository) : super(const RecentInitial()) {
     on<LoadRecent>(_onLoad);
     on<ClearRecentRequested>(_onClear);


### PR DESCRIPTION
The previous refactor removed the field declaration while keeping the constructor initializing formal, causing analysis errors.

https://claude.ai/code/session_01HERPrNUrexnYjvUmm9wSfL