### PR TITLE
fix: show window immediately with splash screen before heavy init

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           # Create launcher script
           cat > "$PKG_DIR/usr/bin/oxicloud" << 'LAUNCHER'
           #!/bin/bash
-          exec /usr/lib/oxicloud/oxicloud_app "$@"
+          exec /usr/lib/oxicloud/OxiCloud "$@"
           LAUNCHER
           chmod +x "$PKG_DIR/usr/bin/oxicloud"
 
@@ -166,7 +166,7 @@ jobs:
 
           cat > %{buildroot}/usr/bin/oxicloud << 'LAUNCHER'
           #!/bin/bash
-          exec /usr/lib/oxicloud/oxicloud_app "\$@"
+          exec /usr/lib/oxicloud/OxiCloud "\$@"
           LAUNCHER
           chmod +x %{buildroot}/usr/bin/oxicloud
 
@@ -207,7 +207,7 @@ jobs:
           cat > AppDir/AppRun << 'APPRUN'
           #!/bin/bash
           APPDIR="$(dirname "$(readlink -f "$0")")"
-          exec "$APPDIR/usr/bin/oxicloud_app" "$@"
+          exec "$APPDIR/usr/bin/OxiCloud" "$@"
           APPRUN
           chmod +x AppDir/AppRun
 
@@ -216,7 +216,7 @@ jobs:
           [Desktop Entry]
           Type=Application
           Name=OxiCloud
-          Exec=oxicloud_app
+          Exec=OxiCloud
           Icon=oxicloud
           Categories=Network;FileTransfer;Utility;
           DESKTOP
@@ -319,7 +319,7 @@ jobs:
           OutputDir=.
           OutputBaseFilename=OxiCloud-windows-x64-setup
           SetupIconFile=assets\icons\installer_icon.ico
-          UninstallDisplayIcon={app}\oxicloud_app.exe
+          UninstallDisplayIcon={app}\OxiCloud.exe
           WizardImageFile=assets\icons\installer_wizard.bmp
           WizardSmallImageFile=assets\icons\installer_wizard_small.bmp
           Compression=lzma
@@ -340,12 +340,12 @@ jobs:
           Source: "build\windows\x64\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
           [Icons]
-          Name: "{group}\OxiCloud"; Filename: "{app}\oxicloud_app.exe"; IconFilename: "{app}\oxicloud_app.exe"
-          Name: "{autodesktop}\OxiCloud"; Filename: "{app}\oxicloud_app.exe"; IconFilename: "{app}\oxicloud_app.exe"; Tasks: desktopicon
-          Name: "{userstartup}\OxiCloud"; Filename: "{app}\oxicloud_app.exe"; Tasks: launchstartup
+          Name: "{group}\OxiCloud"; Filename: "{app}\OxiCloud.exe"; WorkingDir: "{app}"
+          Name: "{autodesktop}\OxiCloud"; Filename: "{app}\OxiCloud.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+          Name: "{userstartup}\OxiCloud"; Filename: "{app}\OxiCloud.exe"; WorkingDir: "{app}"; Tasks: launchstartup
 
           [Run]
-          Filename: "{app}\oxicloud_app.exe"; Description: "Launch OxiCloud"; Flags: nowait postinstall skipifsilent
+          Filename: "{app}\OxiCloud.exe"; Description: "Launch OxiCloud"; Flags: nowait postinstall skipifsilent
           "@ | Out-File -FilePath "installer.iss" -Encoding UTF8
 
           # Download and run InnoSetup

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,64 +33,14 @@ import 'src/rust/frb_generated.dart';
 bool get isDesktop =>
     Platform.isWindows || Platform.isLinux || Platform.isMacOS;
 
-
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  try {
-    // Initialize Flutter-Rust Bridge
-    debugPrint('OxiCloud: Initializing RustLib...');
-    await RustLib.init();
-    debugPrint('OxiCloud: RustLib initialized successfully');
-
-    // Initialize dependency injection
-    await configureDependencies();
-
-    // Initialize Rust core
-    final rustDataSource = getIt<RustBridgeDataSource>();
-    await rustDataSource.initialize();
-
-    // Initialize system tray + window manager for desktop
-    if (isDesktop) {
-      try {
-        final trayService = getIt<SystemTrayService>();
-        await trayService.init();
-
-        final windowManager = DesktopWindowManager(
-          trayService: trayService,
-          rustDataSource: rustDataSource,
-        );
-        await windowManager.init();
-
-        // Wire "Sync Now" tray action to the SyncBloc (deferred until app is built)
-        trayService.onSyncNow = _syncNowFromTray;
-      } catch (e, stackTrace) {
-        // Desktop services are non-critical; log and continue
-        debugPrint('Warning: Desktop service init failed: $e');
-        debugPrint('$stackTrace');
-      }
-    }
-
-    runApp(const OxiCloudAppWrapper());
-  } catch (e, stackTrace) {
-    debugPrint('Fatal initialization error: $e');
-    debugPrint('$stackTrace');
-    await _writeErrorLog('$e\n$stackTrace');
-    runApp(MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: Text(
-              'OxiCloud failed to start.\n\nError: $e',
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 16, color: Colors.red),
-            ),
-          ),
-        ),
-      ),
-    ));
-  }
+  // Show the app immediately with a splash screen so the window becomes
+  // visible. On Windows the native window is only shown after Flutter
+  // renders its first frame (see flutter_window.cpp SetNextFrameCallback).
+  // If we await heavy init before runApp() the window stays invisible.
+  runApp(const OxiCloudBootstrap());
 }
 
 /// Write error log to a file for diagnosing release-build failures.
@@ -120,6 +70,134 @@ void _syncNowFromTray() {
     } on Exception catch (_) {
       // BLoC not yet available
     }
+  }
+}
+
+// =============================================================================
+// Bootstrap widget — shows splash, runs init, then transitions to the real app.
+// =============================================================================
+
+class OxiCloudBootstrap extends StatefulWidget {
+  const OxiCloudBootstrap({super.key});
+
+  @override
+  State<OxiCloudBootstrap> createState() => _OxiCloudBootstrapState();
+}
+
+class _OxiCloudBootstrapState extends State<OxiCloudBootstrap> {
+  bool _ready = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeApp();
+  }
+
+  Future<void> _initializeApp() async {
+    try {
+      debugPrint('OxiCloud: Initializing RustLib...');
+      await RustLib.init();
+      debugPrint('OxiCloud: RustLib initialized successfully');
+
+      await configureDependencies();
+
+      final rustDataSource = getIt<RustBridgeDataSource>();
+      await rustDataSource.initialize();
+
+      // Desktop services (tray + window manager)
+      if (isDesktop) {
+        try {
+          final trayService = getIt<SystemTrayService>();
+          await trayService.init();
+
+          final windowManager = DesktopWindowManager(
+            trayService: trayService,
+            rustDataSource: rustDataSource,
+          );
+          await windowManager.init();
+
+          trayService.onSyncNow = _syncNowFromTray;
+        } catch (e, stackTrace) {
+          debugPrint('Warning: Desktop service init failed: $e');
+          debugPrint('$stackTrace');
+        }
+      }
+
+      if (mounted) setState(() => _ready = true);
+    } catch (e, stackTrace) {
+      debugPrint('Fatal initialization error: $e');
+      debugPrint('$stackTrace');
+      await _writeErrorLog('$e\n$stackTrace');
+      if (mounted) setState(() => _error = e.toString());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_error != null) {
+      return MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: SelectableText(
+                'OxiCloud failed to start.\n\n$_error',
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontSize: 16, color: Colors.red),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (!_ready) {
+      return MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          backgroundColor: const Color(0xFF1A1A2E),
+          body: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Image.asset(
+                  'assets/icons/app_icon.png',
+                  width: 96,
+                  height: 96,
+                  errorBuilder: (_, __, ___) => const Icon(
+                    Icons.cloud,
+                    size: 96,
+                    color: Colors.white,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                const Text(
+                  'OxiCloud',
+                  style: TextStyle(
+                    fontSize: 28,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const SizedBox(
+                  width: 32,
+                  height: 32,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 3,
+                    color: Colors.white70,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return const OxiCloudAppWrapper();
   }
 }
 

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -4,7 +4,7 @@ project(oxicloud_app LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "oxicloud_app")
+set(BINARY_NAME "OxiCloud")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -92,9 +92,9 @@ BEGIN
             VALUE "CompanyName", "DioCrafts" "\0"
             VALUE "FileDescription", "OxiCloud - Fast, secure cloud storage sync" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "oxicloud_app" "\0"
+            VALUE "InternalName", "OxiCloud" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2026 DioCrafts. All rights reserved." "\0"
-            VALUE "OriginalFilename", "oxicloud_app.exe" "\0"
+            VALUE "OriginalFilename", "OxiCloud.exe" "\0"
             VALUE "ProductName", "OxiCloud" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END


### PR DESCRIPTION
Root cause: Windows flutter_window.cpp defers Show() until Flutter renders its first frame via SetNextFrameCallback. Since main() awaited RustLib.init() + rustDataSource.initialize() before calling runApp(), no frame was ever rendered and the window stayed invisible.

Fix: Call runApp() immediately with OxiCloudBootstrap (a StatefulWidget that shows a branded splash screen), then run all async initialization in initState(). The window now appears instantly while Rust/DI/tray init happens in the background.

Also:
- Rename binary from oxicloud_app to OxiCloud (CMakeLists + Runner.rc)
- Update InnoSetup script references to OxiCloud.exe with WorkingDir
- Update Linux launcher scripts for new binary name

https://claude.ai/code/session_01HERPrNUrexnYjvUmm9wSfL